### PR TITLE
Fix issue with nexus 5 - emojis not showing

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,10 +105,11 @@ class EmojiCategory extends Component {
       textAlign: 'center',
       padding: padding,
     }
+    let showCategoryHeader = this.props.showCategoryHeader || false;
 
     return (
      <View style={style.categoryOuter}>
-        <Text style={[styles.headerText, this.props.headerStyle]}>{this.props.category}</Text>
+        {showCategoryHeader ? (<Text style={[styles.headerText, this.props.headerStyle]}>{this.props.category}</Text>) : null}
         <View style={styles.categoryInner}>
           {emojis.map(e => 
             <Text style={style} 

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ class EmojiCategory extends Component {
     let emojis = emojisByCategory[this.props.category]
     let size = this.props.emojiSize || defaultEmojiSize
     let style = {
-      fontSize: size-4,
+      fontSize: size-10,
       color: 'black',
       height: size+4,
       width: size+4,


### PR DESCRIPTION
Hi, yonahforst. On nexus 5 android emulator and mobile device i found a bug that fontSize predefined on your side is occuring a problem with view. Emojis is not got inside container and not displaying at all. This small fix will solve an issue on mobile device, but i guess there maybe something else and exactly this fix wont fit for others?
