### PR TITLE
Fix cropped emoticons

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ class EmojiPicker extends Component {
 
   renderCategory(category) {
     return (
-      <EmojiCategory 
+      <EmojiCategory
         {...this.props}
         key={category}
         category={category}
@@ -110,14 +110,14 @@ class EmojiCategory extends Component {
      <View style={style.categoryOuter}>
         <Text style={[styles.headerText, this.props.headerStyle]}>{this.props.category}</Text>
         <View style={styles.categoryInner}>
-          {emojis.map(e => 
-            <Text style={style} 
-              key={e} 
+          {emojis.map(e =>
+            <Text style={style}
+              key={e}
               onPress={() => this.props.onEmojiSelected(e)}>
               {e}
             </Text>
           )}
-        </View>    
+        </View>
       </View>
     )
   }
@@ -126,7 +126,7 @@ class EmojiCategory extends Component {
 
 const ClearButon = props => {
   return (
-    <TouchableOpacity 
+    <TouchableOpacity
       onPress={() => props.onEmojiSelected(null)}>
       <Text style={[styles.clearButton, props.clearButtonStyle]}>
         {props.clearButtonText || 'Clear'}
@@ -181,7 +181,7 @@ let styles = StyleSheet.create({
   },
   categoryInner: {
     flex: 1,
-    flexWrap: 'wrap', 
+    flexWrap: 'wrap',
     flexDirection: 'column',
   },
   headerText: {

--- a/index.js
+++ b/index.js
@@ -100,8 +100,6 @@ class EmojiCategory extends Component {
     let style = {
       fontSize: size-4,
       color: 'black',
-      height: size+4,
-      width: size+4,
       textAlign: 'center',
       padding: padding,
     }


### PR DESCRIPTION
This pr fixes cropped emoticons on picker on android.

By removing width and height emoticons started to appear correctly.
I am using:
* "react": "16.0.0-alpha.12",
*  "react-native": "^0.48.1"

I tested on ios and android